### PR TITLE
Correct transcription errors in Pomes Penyeach

### DIFF
--- a/src/epub/text/pomes-penyeach.xhtml
+++ b/src/epub/text/pomes-penyeach.xhtml
@@ -77,7 +77,7 @@
 					<span>Than time’s wan wave.</span>
 				</p>
 				<p>
-					<span>Rosefrail and fair⁠–⁠yet frailest</span>
+					<span>Rosefrail and fair⁠—yet frailest</span>
 					<br/>
 					<span>A wonder wild</span>
 					<br/>
@@ -418,9 +418,7 @@
 					<br/>
 					<span>Draw from me still</span>
 					<br/>
-					<span>My slow life! Bend deeper on me, threatening</span>
-					<br/>
-					<span>head,</span>
+					<span>My slow life! Bend deeper on me, threatening head,</span>
 					<br/>
 					<span>Proud by my downfall, remembering, pitying</span>
 					<br/>
@@ -431,9 +429,7 @@
 					<br/>
 					<span>Together, folded by the night, they lay on earth. I hear</span>
 					<br/>
-					<span>From far her low word breathe on my breaking</span>
-					<br/>
-					<span>brain.</span>
+					<span>From far her low word breathe on my breaking brain.</span>
 					<br/>
 					<span><em>Come!</em> I yield. Bend deeper upon me! I am here.</span>
 					<br/>


### PR DESCRIPTION
1. Changed en dash to em dash in "A Flower Given to My Daughter": https://archive.org/details/pomespenyeachoth0000joyc/page/15/mode/1up
2. Removed two erroneous line breaks from the poem "A Prayer": https://archive.org/details/pomespenyeachoth0000joyc/page/25/mode/1up

Both were remnants of the transcription used.

